### PR TITLE
Parser.hs usage + Create/drop table

### DIFF
--- a/client/Main.hs
+++ b/client/Main.hs
@@ -37,7 +37,7 @@ completer n = do
   let names = [
               "select", "*", "from", "show", "table",
               "tables", "insert", "into", "values",
-              "set", "update", "delete"
+              "set", "update", "delete", "drop", "create"
               ]
   return $ Prelude.filter (L.isPrefixOf n) names
 

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -47,7 +47,7 @@ app = do
         setStatus badRequest400
         json SqlErrorResponse { errorMessage = "Request body format is incorrect." }
       Just req -> do
-        result <- liftIO $ runExecuteIO (db appState) $ Lib3.executeSql $ query req
+        result <- liftIO $ runExecuteIO (db appState) $ Lib3.executeSqlWithParser $ query req
         case result of
           Left err -> do
             setStatus badRequest400

--- a/src/Lib2.hs
+++ b/src/Lib2.hs
@@ -13,7 +13,6 @@ module Lib2
     executeStatement,
     ParsedStatement (..),
     SelectQuery (..),
-    RelationalOperator (..),
     SelectData (..),
     Aggregate (..),
     AggregateFunction (..),
@@ -44,20 +43,11 @@ import DataFrame (DataFrame(..), Column(..), ColumnType(..), Value(..), Row)
 import InMemoryTables (TableName, database)
 import Control.Applicative ( many, some, Alternative(empty, (<|>)), optional )
 import Data.Char (toLower, isSpace, isAlphaNum)
+import Parser (RelationalOperator(..))
 
 type ErrorMessage = String
 type Database = [(TableName, DataFrame)]
 type ColumnName = String
-
-data RelationalOperator
-    = RelEQ
-    | RelNE
-    | RelLT
-    | RelGT
-    | RelLE
-    | RelGE
-    deriving (Show, Eq)
-
 
 data LogicalOperator
     = And

--- a/src/Lib3.hs
+++ b/src/Lib3.hs
@@ -192,10 +192,15 @@ executeSqlWithParser sql = case Parser.parseStatement sql of
                     then deleteWithWhere tableData whereConditions
                     else deleteWithoutWhere tableData
     Right (Parser.DropTableStatement tableName) -> do
-        return $ Left "Not implemented"
+        _ <- removeTable tableName
+        return $ Right (DataFrame [] [])
     Right (Parser.CreateTableStatement tableName columns) -> do
-        return $ Left "Not implemented"
-
+        loadResult <- loadTable tableName
+        case loadResult of
+            Left _ -> do
+                saveTable (tableName, DataFrame columns [])
+                return $ Right (DataFrame columns [])
+            Right _ -> return $ Left "Table already exists."
 executeSql :: String -> Execution (Either ErrorMessage DataFrame)
 executeSql sql = case Lib3.parseStatement sql of
     Left errorMsg -> return $ Left errorMsg

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1,7 +1,20 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 
-module Parser ()
+module Parser (
+    ParsedStatement (..),
+    RelationalOperator(..),
+    LogicalOperator(..),
+    Expression(..),
+    AggregateFunction(..),
+    Aggregate(..),
+    WhereCriterion(..),
+    SystemFunction(..),
+    SelectData(..),
+    SelectQuery(..),
+    Condition(..),
+    parseStatement
+    )
 where
 import Control.Monad (void) 
 import Data.Char (isSpace, toLower, isAlphaNum, isDigit)
@@ -11,7 +24,6 @@ import Control.Monad.Trans.State.Strict (State, StateT, get, put, runState, runS
 import Control.Monad.Trans.Class(lift, MonadTrans)
 import DataFrame (DataFrame(..), Column(..), ColumnType(..), Value(..), Row)
 import InMemoryTables (TableName, database)
-
 
 type ErrorMessage = String
 

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -103,7 +103,7 @@ data ParsedStatement = SelectStatement {
     table :: TableName
 } | CreateTableStatement{
     table :: TableName,
-    columns :: [(ColumnName, ColumnType)] 
+    newColumns :: [Column] 
 }deriving (Show, Eq)
 --
 -- monad + state parser
@@ -222,15 +222,15 @@ parseCreateTableStatement = do
     _ <- optional parseWhitespace
     pure $ CreateTableStatement tableName columnsWithType
 
-parseColumnList :: Parser [(ColumnName, ColumnType)]
+parseColumnList :: Parser [Column]
 parseColumnList = parseColumn `sepBy` (optional parseWhitespace *> parseChar ',' <* optional parseWhitespace)
 
-parseColumn :: Parser (ColumnName, ColumnType)
+parseColumn :: Parser Column
 parseColumn = do
     columnName <- parseWord
     _ <- parseWhitespace
     columnType <- parseWord >>= either (throwE . show) pure . parseColumnType
-    pure (columnName, columnType)
+    pure (Column columnName columnType)
 
 parseColumnType :: String -> Either ParseError ColumnType
 parseColumnType "int" = Right IntegerType

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -493,7 +493,7 @@ main = hspec $ do
       Parser.parseStatement input `shouldSatisfy` isLeft
     it "parses create table statement" $ do
       let input = "create table exampleTable (id int , name varchar , flag bool, holidays_from date );"
-      Parser.parseStatement input `shouldBe` Right (Parser.CreateTableStatement {Parser.table = "exampleTable", Parser.columns = [("id",IntegerType),("name",StringType),("flag",BoolType),("holidays_from",DateTimeType)]})
+      Parser.parseStatement input `shouldBe` Right (Parser.CreateTableStatement {Parser.table = "exampleTable", Parser.newColumns = [Column "id" IntegerType,Column "name" StringType,Column "flag" BoolType,Column "holidays_from" DateTimeType]})
     it "handles incorrect create table statement with missed keyword" $ do
       let input = "create exampleTable (id int , name varchar , flag bool, holidays_from date );"
       Parser.parseStatement input `shouldSatisfy` isLeft

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -476,3 +476,27 @@ main = hspec $ do
       db <- setupDB
       res <- runExecuteIO db getCurrentTime $ Lib3.executeSql "DELETE FROM employees where name='Vi'"
       res `shouldBe` Right (DataFrame [Column "id" IntegerType, Column "name" StringType, Column "surname" StringType] [[IntegerValue 2, StringValue "Ed", StringValue "Dl"]])
+    it "parses drop table statement (lowercase)" $ do
+      let input = "drop table tablename;"
+      Parser.parseStatement input `shouldBe` Right (Parser.DropTableStatement { Parser.table = "tablename" })
+    it "parses drop table statement with (mixed case)" $ do
+      let input = "dRoP tAbLe tablename;"
+      Parser.parseStatement input `shouldBe` Right (Parser.DropTableStatement { Parser.table = "tablename" })
+    it "parses drop table statement with (uppercase)" $ do
+      let input = "DROP TABLE tablename;"
+      Parser.parseStatement input `shouldBe` Right (Parser.DropTableStatement { Parser.table = "tablename" })
+    it "parses drop table statement with many whitespaces" $ do
+      let input = "drop    table          tablename;"
+      Parser.parseStatement input `shouldBe` Right (Parser.DropTableStatement { Parser.table = "tablename" })
+    it "handles incorrect drop table statement with missed keyword" $ do
+      let input = "drop tablename;"
+      Parser.parseStatement input `shouldSatisfy` isLeft
+    it "parses create table statement" $ do
+      let input = "create table exampleTable (id int , name varchar , flag bool, holidays_from date );"
+      Parser.parseStatement input `shouldBe` Right (Parser.CreateTableStatement {Parser.table = "exampleTable", Parser.columns = [("id",IntegerType),("name",StringType),("flag",BoolType),("holidays_from",DateTimeType)]})
+    it "handles incorrect create table statement with missed keyword" $ do
+      let input = "create exampleTable (id int , name varchar , flag bool, holidays_from date );"
+      Parser.parseStatement input `shouldSatisfy` isLeft
+    it "handles incorrect create table statement with invalid datatype" $ do
+      let input = "create table exampleTable (id int , name varchar , flag bol, holidays_from date );"
+      Parser.parseStatement input `shouldSatisfy` isLeft


### PR DESCRIPTION
The program now uses our new `Parser.hs` module and can create and delete tables. My main hurdle was that we had multiple definitions of the same data types in different modules. I tried to keep as much of the old code as I could to not mess up the tests, so I mainly "merged" the Lib3 and Parser definitions.

I tried creating the new execute function in a different file, but as it used mostly the same functions it kind of felt like just repeating code. That is why I decided to add it into the Lib3 module.